### PR TITLE
tenacity 9.1.2: rebuild-py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/528.patch
+++ b/recipe/528.patch
@@ -1,0 +1,157 @@
+From da684fa3bb1582fd0553a834a9158e9c39899ac8 Mon Sep 17 00:00:00 2001
+From: Sandro Bonazzola <sandro.bonazzola@gmail.com>
+Date: Tue, 17 Jun 2025 11:23:41 +0200
+Subject: [PATCH 1/4] Fix mypy errors:
+
+```
+tenacity/__init__.py:314: error: Returning Any from function declared to return "dict[str, Any]"  [no-any-return]
+tenacity/__init__.py:322: error: Returning Any from function declared to return "IterState"  [no-any-return]
+Found 2 errors in 1 file (checked 19 source files)
+```
+
+Signed-off-by: Sandro Bonazzola <sandro.bonazzola@gmail.com>
+---
+ tenacity/__init__.py | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/tenacity/__init__.py b/tenacity/__init__.py
+index e274c21..e93793c 100644
+--- a/tenacity/__init__.py
++++ b/tenacity/__init__.py
+@@ -307,19 +307,15 @@ def statistics(self) -> t.Dict[str, t.Any]:
+                   future we may provide a way to aggregate the various
+                   statistics from each thread).
+         """
+-        try:
+-            return self._local.statistics  # type: ignore[no-any-return]
+-        except AttributeError:
++        if not hasattr(self._local, "statistics"):
+             self._local.statistics = t.cast(t.Dict[str, t.Any], {})
+-            return self._local.statistics
++        return self._local.statistics  # type: ignore[no-any-return]
+ 
+     @property
+     def iter_state(self) -> IterState:
+-        try:
+-            return self._local.iter_state  # type: ignore[no-any-return]
+-        except AttributeError:
++        if not hasattr(self._local, "iter_state"):
+             self._local.iter_state = IterState()
+-            return self._local.iter_state
++        return self._local.iter_state  # type: ignore[no-any-return]
+ 
+     def wraps(self, f: WrappedFn) -> WrappedFn:
+         """Wrap a function for retrying.
+
+From 312a04c2639a8cd8598b8701586889b4f3bd2035 Mon Sep 17 00:00:00 2001
+From: Sandro Bonazzola <sandro.bonazzola@gmail.com>
+Date: Tue, 17 Jun 2025 11:45:23 +0200
+Subject: [PATCH 2/4] Refactor `asynctest` decorator
+
+This refactors the original code to work with Python 3.14,
+leveraging `asyncio.run()` for automatic event loop management,
+which is the recommended approach in modern asyncio.
+
+Fixes #527.
+
+Signed-off-by: Sandro Bonazzola <sandro.bonazzola@gmail.com>
+---
+ tests/test_asyncio.py   | 3 +--
+ tests/test_issue_478.py | 3 +--
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/tests/test_asyncio.py b/tests/test_asyncio.py
+index 0b74476..f6793f0 100644
+--- a/tests/test_asyncio.py
++++ b/tests/test_asyncio.py
+@@ -40,8 +40,7 @@
+ def asynctest(callable_):
+     @wraps(callable_)
+     def wrapper(*a, **kw):
+-        loop = asyncio.get_event_loop()
+-        return loop.run_until_complete(callable_(*a, **kw))
++        return asyncio.run(callable_(*a, **kw))
+ 
+     return wrapper
+ 
+diff --git a/tests/test_issue_478.py b/tests/test_issue_478.py
+index 7489ad7..83182ac 100644
+--- a/tests/test_issue_478.py
++++ b/tests/test_issue_478.py
+@@ -12,8 +12,7 @@ def asynctest(
+ ) -> typing.Callable[..., typing.Any]:
+     @wraps(callable_)
+     def wrapper(*a: typing.Any, **kw: typing.Any) -> typing.Any:
+-        loop = asyncio.get_event_loop()
+-        return loop.run_until_complete(callable_(*a, **kw))
++        return asyncio.run(callable_(*a, **kw))
+ 
+     return wrapper
+ 
+
+From 82ddf48a9440da21fdb29e4ac25e44a4d077ef9c Mon Sep 17 00:00:00 2001
+From: Sandro Bonazzola <sandro.bonazzola@gmail.com>
+Date: Tue, 17 Jun 2025 09:58:20 +0200
+Subject: [PATCH 3/4] Test with Python 3.14
+
+Related-To: #527
+Signed-off-by: Sandro Bonazzola <sandro.bonazzola@gmail.com>
+---
+ .github/workflows/ci.yaml     | 10 ++++++----
+ .github/workflows/release.yml |  2 +-
+ .mergify.yml                  |  5 +++--
+ setup.cfg                     |  1 +
+ tox.ini                       |  8 ++++----
+ 5 files changed, 15 insertions(+), 11 deletions(-)
+
+diff --git a/.github/workflows/ci.yaml b/.github/workflows/ci.yaml
+index 4fdd62b..3ecc150 100644
+--- a/.github/workflows/ci.yaml
++++ b/.github/workflows/ci.yaml
+@@ -26,11 +26,13 @@ jobs:
+             tox: py311
+           - python: "3.12"
+             tox: py312
+-          - python: "3.12"
+-            tox: pep8
+           - python: "3.13"
+-            tox: py313,py313-trio
+-          - python: "3.11"
++            tox: py313
++          - python: "3.14"
++            tox: py314,py314-trio
++          - python: "3.14"
++            tox: pep8
++          - python: "3.14"
+             tox: mypy
+     steps:
+       - name: Checkout 🛎️
+diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
+index 1e94465..63e0b7c 100644
+--- a/.github/workflows/release.yml
++++ b/.github/workflows/release.yml
+@@ -20,7 +20,7 @@ jobs:
+ 
+       - uses: actions/setup-python@v5.6.0
+         with:
+-          python-version: 3.13
++          python-version: 3.14
+ 
+       - name: Install build
+         run: |
+diff --git a/.mergify.yml b/.mergify.yml
+index 22cbc6f..142c4f4 100644
+--- a/.mergify.yml
++++ b/.mergify.yml
+@@ -14,8 +14,9 @@ queue_rules:
+       - "check-success=test (3.10, py310)"
+       - "check-success=test (3.11, py311)"
+       - "check-success=test (3.12, py312)"
+-      - "check-success=test (3.13, py313,py313-trio)"
+-      - "check-success=test (3.12, pep8)"
++      - "check-success=test (3.13, py313)"
++      - "check-success=test (3.14, py314,py314-trio)"
++      - "check-success=test (3.14, pep8)"
+ 
+ pull_request_rules:
+   - name: warn on no changelog

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb
 
 build:
-  number: 0
-  skip: True  # [py<37]
+  number: 1
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install -vv --no-deps --no-build-isolation .
 
 requirements:
@@ -44,7 +44,7 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
-  summary: 'Retry a flaky function whenever an exception occurs until it works'
+  summary: Retry a flaky function whenever an exception occurs until it works
   description: |
     Tenacity is general-purpose retrying library, written in Python, to simplify the task of
     adding retry behavior to just about anything. It originates from a fork of Retrying

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,14 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb
+  patches:
+    # Add asyncio support for Python 3.14,
+    # see https://github.com/jd/tenacity/pull/528
+    - 528.patch
 
 build:
   number: 1
-  skip: true  # [py<37]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install -vv --no-deps --no-build-isolation .
 
 requirements:
@@ -33,7 +37,7 @@ test:
   requires:
     - pip
     - pytest
-    - tornado
+    - tornado >=4.5
     - typeguard
   commands:
     - pip check


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11342) 
- [Upstream repository](https://github.com/jd/tenacity/tree/9.1.2)

### Explanation of changes:

- Add a patch with asyncio support for Python 3.14
- Skip py<39

### Notes:

-